### PR TITLE
Enable closed captioning, default to browser's HTTP ACCEPT LANGUAGE

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,6 +2,18 @@ require 'sinatra'
 require 'i18n'
 require 'i18n/backend/fallbacks'
 
+def accepted_locales(http_accept_language = request.env['HTTP_ACCEPT_LANGUAGE'])
+  #
+  # https://gist.github.com/naomik/5546046
+  #
+  return [] if http_accept_language.empty?
+  langs = http_accept_language.scan(/([a-zA-Z]{2,4})(?:-[a-zA-Z]{2})?(?:;q=(1|0?\.[0-9]{1,3}))?/).map do |pair|
+    lang, q = pair
+    [lang.to_sym, (q || '1').to_f]
+  end
+  langs.sort_by { |lang, q| q }.map { |lang, q| lang }.reverse
+end
+
 configure do
   I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
   I18n.load_path += Dir[File.join(settings.root, 'locales', '*.yml')]

--- a/app.rb
+++ b/app.rb
@@ -26,7 +26,7 @@ helpers do
 
   def youtube_iframe_embed(video_id:, **options)
     options = {
-      closed_captioning: true,
+      enable_closed_captioning: true,
       use_http_accept_language: true,
       width: 560,
       height: 315,
@@ -37,7 +37,7 @@ helpers do
 
     uri = URI("https://www.youtube.com/embed/#{video_id}").tap { |uri|
       params = Hash.new.tap { |hash|
-        hash[:cc_load_policy] = 1 if options.delete(:closed_captioning)
+        hash[:cc_load_policy] = 1 if options.delete(:enable_closed_captioning)
         hash[:cc_lang_pref] = accepted_locales.first if options.delete(:use_http_accept_language) && accepted_locales.first
       }
       uri.query = URI.encode_www_form(params)

--- a/app.rb
+++ b/app.rb
@@ -38,7 +38,7 @@ helpers do
     uri = URI("https://www.youtube.com/embed/#{video_id}").tap { |uri|
       params = Hash.new.tap { |hash|
         hash[:cc_load_policy] = 1 if options.delete(:closed_captioning)
-        hash[:cc_lang_pref] = accepted_locales.first if options.delete(:use_http_accept_language)
+        hash[:cc_lang_pref] = accepted_locales.first if options.delete(:use_http_accept_language) && accepted_locales.first
       }
       uri.query = URI.encode_www_form(params)
     }

--- a/app.rb
+++ b/app.rb
@@ -15,7 +15,6 @@ def accepted_locales(http_accept_language = request.env['HTTP_ACCEPT_LANGUAGE'])
 end
 
 helpers do
-
   def content_tag(tag, content = nil, options = {})
     tag = tag.to_s
     html = "<#{tag}"

--- a/views/index.erb
+++ b/views/index.erb
@@ -66,17 +66,17 @@
         <section class="videos video-column">
 
           <!-- Iowa Press -->
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/DahyKQccudQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <%= youtube_iframe_embed(video_id: "DahyKQccudQ") %>
 
           <p class="video-title">Interview on Iowa Press PBS</p>
 
           <!-- Iowa Stump Speech -->
-          <iframe width="300" height="200" src="https://www.youtube.com/embed/GkepAtjSJLI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <%= youtube_iframe_embed(video_id: "GkepAtjSJLI", width: 300, height: 200) %>
 
           <p class="video-title">Iowa Democratic Party Liberty and Justice Speech</p>
 
           <!-- Des Moines Reg -->
-          <iframe width="300" height="200" src="https://www.youtube.com/embed/72fXyHzaNZ4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <%= youtube_iframe_embed(video_id: "72fXyHzaNZ4", width: 300, height: 200) %>
           <p class="video-title">Andrew Yang meets with the Register's editorial board</p>
 
           <div class="mobile-video-nav hide-desktop">
@@ -130,14 +130,12 @@
       <section class="long-form-videos">
         <h2 id="debates">Debate Performances:</h2>
 
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/dNSGMDu58Ok" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/6crg579lpds" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/LVkCfCQDXe8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/3siHgkArebE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/sSbou44OUHg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/eA-69bxpWfs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "dNSGMDu58Ok", width: 300, height: 200) %>
+        <%= youtube_iframe_embed(video_id: "6crg579lpds", width: 300, height: 200) %>
+        <%= youtube_iframe_embed(video_id: "LVkCfCQDXe8", width: 300, height: 200) %>
+        <%= youtube_iframe_embed(video_id: "3siHgkArebE", width: 300, height: 200) %>
+        <%= youtube_iframe_embed(video_id: "sSbou44OUHg", width: 300, height: 200) %>
+        <%= youtube_iframe_embed(video_id: "eA-69bxpWfs", width: 300, height: 200) %>
       </section>
       <section class="long-form-videos">
         <h2 id="longform">
@@ -145,31 +143,31 @@
         </h2>
 
         <!-- Joe Rogan -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/cTsEzmFamZ8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "cTsEzmFamZ8", width: 300, height: 200) %>
 
         <!-- Karen Hunter -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/XAehF8ZdwIU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "XAehF8ZdwIU", width: 300, height: 200) %>
 
         <!-- Useful Idiots -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/iKuZppYwnq4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "iKuZppYwnq4", width: 300, height: 200) %>
 
         <!-- Van Jones -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/kzvi4QBBnec" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "kzvi4QBBnec", width: 300, height: 200) %>
 
         <!-- Wapo -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/2aebkCjUSgk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "2aebkCjUSgk", width: 300, height: 200) %>
 
         <!-- Shaprio -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/-DHuRTvzMFw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "-DHuRTvzMFw", width: 300, height: 200) %>
 
         <!-- Breakfast Club -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/87M2HwkZZcw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "87M2HwkZZcw", width: 300, height: 200) %>
 
         <!-- h3 -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/2HXVws8ZQRc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "2HXVws8ZQRc", width: 300, height: 200) %>
 
         <!-- Off the pill -->
-        <iframe width="300" height="200" src="https://www.youtube.com/embed/_P5P4_ISofI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <%= youtube_iframe_embed(video_id: "_P5P4_ISofI", width: 300, height: 200) %>
       </section>
     </div>
 


### PR DESCRIPTION
This PR enables the embedded YT videos to have closed captioning enabled by default, defaulting to the browser's perferred language setting.

src: https://stackoverflow.com/questions/7113736/detect-browser-language-in-rails.

I've only briefly tested this with my own Chrome settings:  

![image](https://user-images.githubusercontent.com/2739640/72299459-e402b680-362e-11ea-9837-3b1592d52c01.png)

```
> request.env['HTTP_ACCEPT_LANGUAGE']
=> "af,es;q=0.9,en;q=0.8"
> accepted_locales
=> [:af, :es, :en]
```

I created a helper to build the `iframe` elements, applying the [YT player parameters](https://developers.google.com/youtube/player_parameters) to the video URL. 

If the video has a subtitle available for that ISO 639-1 two-letter language code, it will select it. If not, it may default to english, or some other default. I tested with Justin Beiber's new music video, Yummy, which has subs for several languages. In my example, the Yummy video doesn't have an Afrikaans subtitle track, so it displayed English instead. To see it in action:
```
<%= youtube_iframe_embed(video_id: "8EJ3zbKTWQ8") %>
```