### PR TITLE
Enable live reload and pry when in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 gem 'sinatra'
 gem 'i18n'
 gem 'rack-contrib'
+gem 'pry', group: :development
+gem 'sinatra-contrib', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    backports (3.15.0)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    method_source (0.9.2)
+    multi_json (1.14.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (2.1.1)
     rack-contrib (2.1.0)
       rack (~> 2.0)
@@ -17,6 +24,13 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    sinatra-contrib (2.0.8.1)
+      backports (>= 2.8.2)
+      multi_json
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.8.1)
+      sinatra (= 2.0.8.1)
+      tilt (~> 2.0)
     tilt (2.0.10)
 
 PLATFORMS
@@ -24,8 +38,10 @@ PLATFORMS
 
 DEPENDENCIES
   i18n
+  pry
   rack-contrib
   sinatra
+  sinatra-contrib
 
 BUNDLED WITH
    1.17.2

--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,11 @@
 require 'sinatra'
 require 'i18n'
 require 'i18n/backend/fallbacks'
+require "sinatra/reloader" if development?
+
+configure :development do
+  enable :reloader
+end
 
 configure do
   I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)


### PR DESCRIPTION
This PR adds live-reload to the project.

Despite having a volume for the local app directory, https://github.com/thedeeno/Yang/blob/master/docker-compose.yml#L7, live-reload doesn't work unless explicitly enabled